### PR TITLE
fix "failed to load etebase"

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,11 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
     <script
-
-      src="https://ga.jspm.io/npm:es-module-shims@1.0.0/dist/es-module-shims.js"
+      async
+      src="https://ga.jspm.io/npm:es-module-shims@1.4.1/dist/es-module-shims.js"
       crossorigin="anonymous"
     ></script>
-
   </head>
 
   <body>


### PR DESCRIPTION
Hey, looks like you were missing `async` in the polyfill script
but I have some bad news for you :(
looks like etebase is using node modules I'm not sure how vite polyfills those but at least in perla we don't have a way to polyfill them

I tried with a couple of import maps to see if something could work but since this package relies on node, it doesn't seem to work with any known CDN, I think your best bet is to keep using vite for this :(

Here are some of the import maps I tried
---
using `dotnet perla add -p etebase -s jspm`
```json
{
  "imports": {
    "etebase": "https://ga.jspm.io/npm:etebase@0.43.1/dist/umd/Etebase.js"
  },
  "scopes": {
    "https://ga.jspm.io/": {
      "buffer": "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.14/nodelibs/browser/buffer.js",
      "process": "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.14/nodelibs/browser/process.js"
    }
  }
}
```
but this fails because jspm gives us a UMD bundle not the ESM version

This one fails because there is no ESM version of `https://unpkg.com/urijs@1.19.7?module`
```
{
  "imports": {
    "etebase": "https://unpkg.com/etebase@0.43.1?module"
  },
  "scopes": {}
}
```

Also I tried with https://www.jsdelivr.com/esm but we get this error

`Uncaught SyntaxError: The requested module '/npm/libsodium@0.7.6/+esm' does not provide an export named 'default'`
```
{
  "imports": {
    "etebase": "https://cdn.jsdelivr.net/npm/etebase/+esm"
  },
  "scopes": {}
}
```

So I'm not really sure how to help you here :( packages that depend on node are unlikely to ever work in Perla